### PR TITLE
Fix blog post dates to use NZ timezone instead of UTC

### DIFF
--- a/pipeline/BlogPostPublisher.cs
+++ b/pipeline/BlogPostPublisher.cs
@@ -20,8 +20,7 @@ public static class BlogPostPublisher
         var generatedAt  = successful[0].Insight!.GeneratedAt;
         var slug         = generatedAt.ToString("yyyy-MM-dd");
         var friendlyDate = generatedAt.ToString("dddd, d MMMM yyyy");
-        // NZDT (UTC+13) applies Oct–Mar; NZST (UTC+12) applies Apr–Sep
-        var tzLabel      = generatedAt.Month is >= 10 or <= 3 ? "NZDT" : "NZST";
+        var tzLabel      = generatedAt.Offset.Hours == 13 ? "NZDT" : "NZST";
 
         // One H3 block per successful model
         var modelSections = string.Join(

--- a/pipeline/GardenInsightParser.cs
+++ b/pipeline/GardenInsightParser.cs
@@ -6,9 +6,12 @@ namespace GardenAI;
 /// </summary>
 internal static class GardenInsightParser
 {
+    private static readonly TimeZoneInfo NzTz =
+        TimeZoneInfo.FindSystemTimeZoneById("Pacific/Auckland");
+
     internal static string BuildPrompt(string promptTemplate, WeatherForecast forecast, List<GardenBed> beds, DaylightInfo? daylight = null)
     {
-        var season = DateTimeOffset.Now.Month switch
+        var season = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, NzTz).Month switch
         {
             12 or 1 or 2 => "summer",
             3 or 4 or 5  => "autumn",
@@ -81,7 +84,7 @@ internal static class GardenInsightParser
             sections[currentSection] = currentContent.ToString().Trim();
 
         return new GardenInsight(
-            GeneratedAt:   DateTimeOffset.Now,
+            GeneratedAt:   TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, NzTz),
             Summary:       sections.GetValueOrDefault("Summary", ""),
             Observations:  sections.GetValueOrDefault("Observations", ""),
             Actions:       sections.GetValueOrDefault("Actions", ""),


### PR DESCRIPTION
DateTimeOffset.Now on the GHA runner returns UTC, so posts were being
dated a day behind (e.g. Feb 28 when it was already Mar 1 in NZ).

- Convert UtcNow to Pacific/Auckland before setting GeneratedAt
- Derive NZDT/NZST label from the actual UTC offset rather than guessing by month

https://claude.ai/code/session_01A3rYy3jihwZCyBqStDAhXx